### PR TITLE
Change order to have executable running as xteve user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ RUN unzip -o /tmp/xteve_linux_amd64.zip -d /xteve
 # Clean up the .zip
 RUN rm /tmp/xteve_linux_amd64.zip
 
-# Set executable permissions
-RUN chmod +x /xteve/xteve
-
 # Add user for VLC and ffmpeg
 RUN addgroup -S xteve && adduser -S xteve -G xteve
+
+# Set executable permissions
+RUN chmod +x /xteve/xteve
+RUN chown xteve:xteve /xteve/xteve
 
 # Set user contexts
 USER xteve
@@ -42,7 +43,7 @@ EXPOSE 34400
 # Healthcheck
 HEALTHCHECK --interval=30s --start-period=30s --retries=3 --timeout=10s \
   CMD curl -f http://localhost:34400/ || exit 1
-  
+
 # Entrypoint should be the base command
 ENTRYPOINT ["/xteve/xteve"]
 


### PR DESCRIPTION
Right now, I'm getting an error, when a new version of xteve is found.

`2020/02/25 07:47:17 [xTeVe] [ERROR] open /xteve/xteve: permission denied (Update failed) - EC: 6002`

This PR fixes this issue.